### PR TITLE
Add Simple dotnet core CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,40 @@
+# Simple C#/.NET CI Build.
+# Test, that the repository contains a clean and working code.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Test
+        run: |
+          cd ./TimeTracker
+          dotnet test --no-build --verbosity normal
+
+      - name: Build
+        run: |
+          cd ./TimeTracker
+          dotnet build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: time-tracker-debug
+          path: bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,3 +38,27 @@ jobs:
         with:
           name: time-tracker-debug
           path: bin
+
+  lintformat:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: false
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Prepare formatter tool
+        run: |
+          dotnet tool install --global format
+
+      - name: Lint
+        run: |
+          cd ./TimeTracker
+          dotnet format --verify-no-changes


### PR DESCRIPTION
Add a simple Dotnet Core CI for the simple program.

Also retrieve the debug output in the artifact files.

[![.github/workflows/build.yaml](https://github.com/salman7C9/work-tracker/actions/workflows/build.yaml/badge.svg?branch=simple_ci)](https://github.com/salman7C9/work-tracker/actions/workflows/build.yaml)